### PR TITLE
MNT: Update to v0.7.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '0.7.5' %}
+{% set version = '0.7.6' %}
 {% set posix = 'm2-' if win else '' %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/carpentries/pegboard/archive/refs/tags/{{ version }}.tar.gz
-  sha256: c2db8e85521a599dec6d2a483712a82c4ecec7cf9e9d5b51c1b25e3b9f3c81c7
+  sha256: 64c6445d7ee60d3b787e2d5adb38df7821d242ab1b74508291dfad44bc22b930
 
 build:
   number: 0
@@ -33,7 +33,7 @@ requirements:
     - r-fs >=1.5.0
     - r-glue
     - r-purrr
-    - r-tinkr >=0.2.0
+    - r-tinkr >=0.3.0
     - r-xml2
     - r-xslt
     - r-yaml
@@ -44,7 +44,7 @@ requirements:
     - r-fs >=1.5.0
     - r-glue
     - r-purrr
-    - r-tinkr >=0.2.0
+    - r-tinkr >=0.3.0
     - r-xml2
     - r-xslt
     - r-yaml


### PR DESCRIPTION
* Update to pegboard v0.7.6.
   - c.f. https://github.com/carpentries/pegboard/releases/tag/0.7.6
* Require r-tinkr lower bound of 0.3.0 as pegboard v0.7.6+ relied on unreleased versions of tinkr.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
